### PR TITLE
Rename 'Booking Calendar' to 'Booking History'

### DIFF
--- a/Seminarhall-booking-app/src/screens/BookedCalendarScreen.tsx
+++ b/Seminarhall-booking-app/src/screens/BookedCalendarScreen.tsx
@@ -276,7 +276,7 @@ const BookedCalendarScreen: React.FC<BookedCalendarScreenProps> = ({
 						color={dynamicTheme.colors.text.primary}
 					/>
 				</TouchableOpacity>
-				<Text style={styles.headerTitle}>Booking Calendar</Text>
+				<Text style={styles.headerTitle}>Booking History</Text>
 				<TouchableOpacity onPress={handleRefresh} style={styles.refreshButton}>
 					<Ionicons name="refresh" size={24} color={theme.colors.primary} />
 				</TouchableOpacity>
@@ -429,14 +429,7 @@ const BookedCalendarScreen: React.FC<BookedCalendarScreenProps> = ({
 								<Text style={styles.noBookingsText}>
 									No bookings for this day
 								</Text>
-								<TouchableOpacity
-									style={styles.createBookingButton}
-									onPress={() => navigation.navigate("BookingForm", {})}
-								>
-									<Text style={styles.createBookingButtonText}>
-										Create Booking
-									</Text>
-								</TouchableOpacity>
+								
 							</View>
 						) : (
 							<View style={styles.bookingsList}>

--- a/Seminarhall-booking-app/src/screens/HomeScreen.tsx
+++ b/Seminarhall-booking-app/src/screens/HomeScreen.tsx
@@ -465,7 +465,7 @@ export default function HomeScreen({ navigation }: { navigation: any }) {
 
 		// Add role-specific actions
 		if (user && ["admin", "super_admin"].includes(user.role)) {
-			// Admin gets both admin panel and booking calendar
+			// Admin gets both admin panel and booking history
 			baseActions.push({
 				id: "admin",
 				title: "Admin Panel",
@@ -478,7 +478,7 @@ export default function HomeScreen({ navigation }: { navigation: any }) {
 			});
 			baseActions.push({
 				id: "schedule",
-				title: "Booking Calendar",
+				title: "Booking History",
 				description: "View all schedules",
 				icon: "today",
 				colors: isDark
@@ -487,10 +487,10 @@ export default function HomeScreen({ navigation }: { navigation: any }) {
 				iconColor: "#6366f1",
 			});
 		} else {
-			// For regular users, show booking calendar
+			// For regular users, show booking history
 			baseActions.push({
 				id: "schedule",
-				title: "Booking Calendar",
+				title: "Booking History",
 				description: "View all schedules",
 				icon: "today",
 				colors: isDark


### PR DESCRIPTION
Updated UI labels and references from 'Booking Calendar' to 'Booking History' in BookedCalendarScreen and HomeScreen for consistency and clarity. Also removed the 'Create Booking' button from the empty state in BookedCalendarScreen.